### PR TITLE
Moved OHHTTPStubs dependency to private Cartfile

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,4 +1,3 @@
 github "Alamofire/Alamofire" ~> 4.6
-github "AliSoftware/OHHTTPStubs" ~> 6.0
 github "filestack/filestack-swift" ~> 1.2.4
 github "ZipArchive/ZipArchive" ~> 2.1

--- a/Cartfile.private
+++ b/Cartfile.private
@@ -1,0 +1,1 @@
+github "AliSoftware/OHHTTPStubs" ~> 6.0


### PR DESCRIPTION
Moved OHHTTPStubs dependency to [Cartfile.private](https://github.com/Carthage/Carthage/blob/master/Documentation/Artifacts.md).

When adding the Filestack iOS SDK as a dependency via Carthage developers need to download and build the `OHHTTPStubs.framework` when executing `carthage update` which is only used by Unit-Test of the Filestack iOS SDK.