### PR TITLE
Fixed disabled User-Interaction Bug 🐞

### DIFF
--- a/Filestack/Models/Client.swift
+++ b/Filestack/Models/Client.swift
@@ -133,7 +133,7 @@ internal typealias CompletionHandler = (_ response: CloudResponse, _ safariError
                                                          useIntelligentIngestionIfAvailable: Bool = true,
                                                          queue: DispatchQueue = .main,
                                                          uploadProgress: ((Progress) -> Void)? = nil,
-                                                         completionHandler: @escaping ([NetworkJSONResponse]) -> Void) -> CancellableRequest {
+                                                         completionHandler: @escaping ([NetworkJSONResponse]?) -> Void) -> CancellableRequest {
 
         let mfu = client.multiFileUpload(storeOptions: storeOptions,
                                          useIntelligentIngestionIfAvailable: useIntelligentIngestionIfAvailable,
@@ -157,6 +157,9 @@ internal typealias CompletionHandler = (_ response: CloudResponse, _ safariError
                 progress.completedUnitCount = 0
 
                 uploadProgress?(progress)
+            } else {
+                // Picking from ImagePicker has been cancelled
+                completionHandler(nil)
             }
         }
 
@@ -184,7 +187,7 @@ internal typealias CompletionHandler = (_ response: CloudResponse, _ safariError
                                                             useIntelligentIngestionIfAvailable: Bool = true,
                                                             queue: DispatchQueue = .main,
                                                             uploadProgress: ((Progress) -> Void)? = nil,
-                                                            completionHandler: @escaping ([NetworkJSONResponse]) -> Void) -> CancellableRequest {
+                                                            completionHandler: @escaping ([NetworkJSONResponse]?) -> Void) -> CancellableRequest {
 
         
         let mfu = client.multiFileUpload(storeOptions: storeOptions,
@@ -208,6 +211,9 @@ internal typealias CompletionHandler = (_ response: CloudResponse, _ safariError
                 progress.completedUnitCount = 0
 
                 uploadProgress?(progress)
+            } else {
+                // Picking from DocumentPicker has been cancelled
+                completionHandler(nil)
             }
         }
 

--- a/Filestack/UI/Controllers/SourceTableViewController.swift
+++ b/Filestack/UI/Controllers/SourceTableViewController.swift
@@ -180,12 +180,16 @@ private extension SourceTableViewController {
             self.uploadMonitorViewController?.updateProgress(value: fractionCompleted)
         }
 
-        let completionHandler: (([NetworkJSONResponse]) -> Void) = { (responses) in
+        let completionHandler: (([NetworkJSONResponse]?) -> Void) = { (responses) in
             // Nil the reference to the request object, so the object can be properly deallocated.
             cancellableRequest = nil
             // Re-enable user interaction.
             self.view.isUserInteractionEnabled = true
-
+            // Verify responses are available
+            guard let responses = responses else {
+                // Responses are unavailable (Cancel-Action)
+                return
+            }
             let errors = responses.compactMap { $0.error }
             if let error = errors.first {
                 self.showErrorAlert(message: error.localizedDescription)


### PR DESCRIPTION
When selecting to upload media from either Camera, Photo-Library or Document-Picker and the user presses cancel to get back to the `SourceTableViewController` the `userInteraction` is still disabled as the `completionHandler` is not being called to re-enable the `userInteraction`. The `completionHandler` will only be called when uploading a media item which enables the `userInteraction` again.

By updating the `completionHandler` closure signature from `([NetworkJSONResponse]) -> Void)` to `([NetworkJSONResponse]?) -> Void)` and invoke them with `completionHandler(nil)` when the `filePickedCompletionHandler` will return false to re-enable the `userInteraction`.