### PR TITLE
Crash fixed + repo Package made buildable again

### DIFF
--- a/Sources/Filestack/Internal/Requests/LogoutRequest.swift
+++ b/Sources/Filestack/Internal/Requests/LogoutRequest.swift
@@ -31,7 +31,7 @@ final class LogoutRequest {
         let task = URLSession.filestackDefault.dataTask(with: request) { (data, response, error) in
             let response = LogoutResponse(error: error)
 
-            completionBlock(response)
+            DispatchQueue.main.async { completionBlock(response) }
         }
 
         task.resume()

--- a/Sources/Filestack/Public/Models/Client.swift
+++ b/Sources/Filestack/Public/Models/Client.swift
@@ -345,7 +345,9 @@ private extension Client {
             }
 
             // Set the presentation context provider
-            session.presentationContextProvider = self
+            if #available(iOS 13.0, *) {
+                session.presentationContextProvider = self
+            }
             
             // Keep a strong reference to the auth session.
             self.safariAuthSession = session

--- a/Sources/Filestack/UI/Internal/Controllers/DocumentPickerUploadController.swift
+++ b/Sources/Filestack/UI/Internal/Controllers/DocumentPickerUploadController.swift
@@ -17,14 +17,22 @@ class DocumentPickerUploadController: URLPickerUploadController {
          viewController: UIViewController,
          config: Config,
          completionBlock: (([URL]) -> Void)? = nil) {
-        let allowedContentTypes = config.documentPickerAllowedUTIs.compactMap { UTIString in
-            if let contentType = UTType(UTIString) {
-                return contentType
-            } else {
-                return nil
-            }
+        if #available(iOS 14.0, *) {
+            let allowedContentTypes: [UTType] = config.documentPickerAllowedUTIs
+                .compactMap { UTType($0) }
+            self.picker = UIDocumentPickerViewController(
+                forOpeningContentTypes: allowedContentTypes.isEmpty ? [UTType.item] : allowedContentTypes,
+                asCopy: true
+            )
+        } else {
+            let docTypes: [String] = config.documentPickerAllowedUTIs.isEmpty
+                ? ["public.item"]
+                : config.documentPickerAllowedUTIs
+            self.picker = UIDocumentPickerViewController(
+                documentTypes: docTypes,
+                in: .import
+            )
         }
-        self.picker = UIDocumentPickerViewController(forOpeningContentTypes: allowedContentTypes.isEmpty ? [.item] : allowedContentTypes, asCopy: true)
         super.init(uploader: uploader,
                    viewController: viewController,
                    presentedViewController: picker,

--- a/Sources/Filestack/UI/Internal/PhotoPicker/AlbumList/AlbumListViewController.swift
+++ b/Sources/Filestack/UI/Internal/PhotoPicker/AlbumList/AlbumListViewController.swift
@@ -79,7 +79,13 @@ private extension AlbumListViewController {
 private extension AlbumListViewController {
     func createAndStartLaodingView() {
         DispatchQueue.main.async {
-            let indicator = UIActivityIndicatorView(style: .medium)
+            let style: UIActivityIndicatorView.Style
+            if #available(iOS 13.0, *) {
+                style = .medium
+            } else {
+                style = .gray
+            }
+            let indicator = UIActivityIndicatorView(style: style)
             indicator.center = self.view.center
             indicator.startAnimating()
             self.view.addSubview(indicator)


### PR DESCRIPTION
First - app is crashing on logout button press because of UI code is being called from background network thread.
Second - repo claims itself as iOS 11 compatible but there were several places where it was using more modern SDK versions without fallback to older version